### PR TITLE
Update to ubuntu 22.04, gdal 3.4, python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,22 @@
-FROM ubuntu:18.10
+FROM ubuntu:22.04
 
 LABEL Maintainer="James Hiebert <hiebert@uvic.ca>"
 
-# WARNING: This should be removed with the introduction of 20.04
-RUN sed -i 's/archive.ubuntu.com/old-releases.ubuntu.com/g;s/security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
-    apt-get -yq install \
-    libhdf5-dev \
-    libnetcdf-dev \
-    libgdal-dev \
-    libyaml-dev \
-    python \
-    python-dev \
-    python-pip \
-    python-virtualenv \
-    cython \
-    python3 \
-    python3-dev \
-    python3-pip \
-    cython3 && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update
+RUN apt-get -yq install libhdf5-dev libnetcdf-dev
+RUN apt-get -yq install libyaml-dev libgdal-dev
+RUN apt-get -yq install python3 python3-dev python3-pip
+RUN apt-get -yq install cython3
+
+RUN rm -rf /var/lib/apt/lists/*
 
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
 
-RUN pip install -U pip && python3 -m pip install -U pip
+RUN python3 -m pip install -U pip
 
-RUN pip install numpy && pip3 install numpy
+RUN pip3 install numpy
 
-RUN pip install gdal==2.3.1 h5py netCDF4 psycopg2 PyYAML pillow
-
-RUN pip3 install gdal==2.3.1 h5py netCDF4 psycopg2 PyYAML pillow
+RUN pip3 install gdal==3.4.1 h5py netCDF4 psycopg2 PyYAML pillow

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,16 @@ LABEL Maintainer="James Hiebert <hiebert@uvic.ca>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update
-RUN apt-get -yq install libhdf5-dev libnetcdf-dev
-RUN apt-get -yq install libyaml-dev libgdal-dev
-RUN apt-get -yq install python3 python3-dev python3-pip
-RUN apt-get -yq install cython3
-
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -yq \
+    libhdf5-dev \
+    libnetcdf-dev \
+    libyaml-dev \
+    libgdal-dev \
+    python3 \
+    python3-dev \
+    python3-pip \
+    cython3 && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal


### PR DESCRIPTION
This branch updates ubuntu to 22.04, gdal to 3.4.1, and python to 3.10.  It drops support for python 2.x, which gets tricker in ubuntu 22.04, and I don't think we're using it any more.

The goal was [to fix the climate explorer backend build](https://github.com/pacificclimate/climate-explorer-backend/issues/233). Here is a [demo](https://beehive.pacificclimate.org/scip/app/) of SCIP running with the fixed climate explorer backend built from this docker.

Aside from climate-explorer-backend, sandpiper seems to be the only repository currently using this container. [It appears to be using a custom branch](https://github.com/pacificclimate/sandpiper/blob/3e26eb904a1e2d06bc41035ed02e62e2d63dadec/Dockerfile#L1) named "gdal3" and probably won't be affected by this update, though since this update has gdal 3.4, perhaps we should see if it can use this one as well so we have one fewer build to maintain.
