### PR TITLE
Maintenance upgrades

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   publish:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL Maintainer="James Hiebert <hiebert@uvic.ca>"
 
@@ -18,8 +18,6 @@ RUN apt-get update && apt-get install -yq \
 ENV CPLUS_INCLUDE_PATH=/usr/include/gdal
 ENV C_INCLUDE_PATH=/usr/include/gdal
 
-RUN python3 -m pip install -U pip
+RUN pip install numpy --break-system-packages
 
-RUN pip3 install numpy
-
-RUN pip3 install gdal==3.4.1 h5py netCDF4 psycopg2 PyYAML pillow
+RUN pip install gdal==3.8.4 h5py netCDF4 psycopg2 PyYAML pillow --break-system-packages


### PR DESCRIPTION
This PR upgrades to Ubuntu 24.04, GDAL 3.8, and Python 3.12.

Python 3.12 heavily encourages users to install libraries into a virtual environment such as `pipx`, `poetry`, or `venv`. However, in this case, which creates a single-purpose docker container as a base for specific applications, I think we are justified to use the  `--break-system-packages` argument to override 3.12's preferences; we're not concerned about any hypothetical other python applications getting their dependencies scrambled by a systemwide python library install.

(Draft until we've verified that other applications built on top of this still work.)